### PR TITLE
p7zip-full is needed on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can clone the repo and run the script from within it.  Instructions to do so
 
 To my knowledge this should work in virtually any Linux install that has access to bash and basic utilities.  `wget`, `ln`, `find`, `awk`, `sed`, `unzip`, `7z`*.  You need a local copy of WINE installed -- the version itself doesn't matter, but if you'll be using your local copy of WINE to ***play*** the game, you'll need 4.2 or above to get shaders to work.
 
-\* As of 02-23-21, `7z` (generally provided by the `p7zip` package in most distros) is also required.  If you have a reliable source of the required 32-bit d3dcompiler that doesn't need it, I'm open to removing the requirement, but right now we're using the winetricks method.
+\* As of 02-23-21, `7z` (generally provided by the `p7zip` package in most distros, `p7zip-full` on Ubuntu) is also required.  If you have a reliable source of the required 32-bit d3dcompiler that doesn't need it, I'm open to removing the requirement, but right now we're using the winetricks method.
 
 ### Installation
 


### PR DESCRIPTION
Ubuntu is one of the more popular distributions, and the standard p7zip package is not enough to satisfy the requirement there, at least on Ubuntu 20.04.3 LTS.