### PR TITLE
Added installation step for Rosetta

### DIFF
--- a/gshade_installer.sh
+++ b/gshade_installer.sh
@@ -544,6 +544,16 @@ installGame() {
   if [ $? != 0 ] || [ ! -L "d3dcompiler_47.dll" ]; then cp "$GShadeHome/d3dcompiler_47s/d3dcompiler_47.dll.${ARCH}bit" d3dcompiler_47.dll; fi
   ln -sfn "$GShadeHome/GShade${ARCH}.dll" "${gapi}".dll
   if [ $? != 0 ] || [ ! -L "${gapi}.dll" ]; then cp "$GShadeHome/GShade${ARCH}.dll" "$gapi".dll; fi
+  # Check to see if we're running under Rosetta.
+  # If we are, link the non-AVX DLLs as Rosetta does not support these instructions.
+  if [ "$IS_MAC" = true ] ; then
+    isRosetta=$(arch -x86_64 sysctl -a | grep machdep.cpu.features | grep AVX)
+    if [ -z "$isRosetta" ]; then
+      printf "Detected Rosetta on macOS. Non-AVX DLLs will be linked. "
+      ln -sfn "$GShadeHome/Legacy (Non-AVX)/GShade${ARCH}.dll" "${gapi}".dll
+      if [ $? != 0 ] || [ ! -L "${gapi}.dll" ]; then cp "$GShadeHome/Legacy (Non-AVX)/GShade${ARCH}.dll" "$gapi".dll; fi
+    fi
+  fi
   if [ ! -f "GShade.ini" ]; then cp "$GShadeHome/GShade.ini" "GShade.ini"; fi
   ln -sfn "$GShadeHome/gshade-shaders" "gshade-shaders"
   if [ $? != 0 ] || [ ! -L "gshade-shaders" ]; then cp -a "$GShadeHome/gshade-shaders" "gshade-shaders"; fi


### PR DESCRIPTION
Hi,

Recent versions of GShade started shipping DLLs that require AVX by default.

When running GShade under Wine/Rosetta, AVX is not supported as M1/M2 chips can't translate the instruction, resulting in a game crash when this script is used.

I've added a step to the installer to check for when AVX support is missing under macOS and link the non-AVX DLLs instead (which is still shipped by GShade).

I tried to make as few changes as possible here to avoid introducing regressions for non-Mac systems. I unfortunately don't have a Linux machine on me but I have tested this with XIV on Mac using separate Macs with Intel/M1 CPUs and verified that the correct DLL was being linked for each.

Thanks!