### PR TITLE
Make force updating available via the interactive menu

### DIFF
--- a/gshade_installer.sh
+++ b/gshade_installer.sh
@@ -802,6 +802,7 @@ menu() {
 	2) Install to a custom game
 	P) Update presets only
 	F) Attempt auto-install for FFXIV
+	U) Force update GShade installation
 	B) Create a backup of existing GShade game installations
 	S) Show games GShade is installed to
 	L) Change GShade's language
@@ -823,6 +824,7 @@ stepByStep() {
       [1]* ) printf "\n"; update;;
       [2]* ) printf "\n"; customGamePrompt; customGame; break;;
       [Ff]* ) XIVinstall; break;;
+      [Uu]* ) printf "\n"; forceUpdate=1; update;;
       [Pp]* ) presetUpdate; printf "Done!\n"; break;;
       [Bb]* ) performBackup; printf "Done!\n"; break;;
       [Ss]* ) listGames; if [ $? ]; then printf "%b" "\n$gamesList"; else printf "\nNo games yet installed to.\n"; fi;;


### PR DESCRIPTION
Hi,

Some XIV on Mac users seem to be having issues with updating their GShade installs, where the script reports that it is up to date when the install isn't.

I can see there's an `update force` flag that can be passed but we don't currently provide a way for users to specify arguments.

Would it be okay to make this option part of the interactive menu as well?