### PR TITLE
Shift XoM installation block

### DIFF
--- a/gshade_installer.sh
+++ b/gshade_installer.sh
@@ -647,21 +647,22 @@ XIVinstall() {
   # This will be relevant if it exists.
   lutrisYaml=($(find "$XDG_CONFIG_HOME"/lutris/games/ -name 'final-fantasy-xiv*' -print 2>/dev/null))
   xlcoreini=($(find "$HOME"/.xlcore/ -name 'launcher.ini' -print 2>/dev/null))
+	
+	if [[ "$IS_MAC" = "true" ]] && [[ -d "/Applications/XIV on Mac.app" ]]; then
+		WINEPREFIX="$HOME/Library/Application Support/XIV on Mac/wineprefix"
+		gameLoc="$(defaults read dezent.XIV-on-Mac GamePath)/game/"
+		gapi=d3d11;
+		printf "\n $gameLoc"
+		printf "\nIf you have a MacBook Pro it's Fn+Shift+f2 to open the gshade window!"
+		printf "\nXIV on Mac detected.\n"
+		printf "\nInstalling...  ";
+		installGame
+		printf "Complete!\n"
+		exit 0
+	fi
 
   if [ -z "$WINEPREFIX" ]; then WINEPREFIX="$HOME/.wine"; fi
   if ( validPrefix ); then
-    if [[ "$IS_MAC" = "true" ]] && [[ -d "/Applications/XIV on Mac.app" ]]; then
-      WINEPREFIX="$HOME/Library/Application Support/XIV on Mac/wineprefix"
-      gameLoc="$(defaults read dezent.XIV-on-Mac GamePath)/game/"
-      gapi=d3d11;
-      printf "\n $gameLoc"
-      printf "\nIf you have a MacBook Pro it's Fn+Shift+f2 to open the gshade window!"
-      printf "\nXIV on Mac detected.\n"
-      printf "\nInstalling...  ";
-      installGame
-      printf "Complete!\n"
-      exit 0
-    fi
 
     gameLoc="$WINEPREFIX/drive_c/Program Files (x86)/SquareEnix/FINAL FANTASY XIV - A Realm Reborn/game/"
 

--- a/gshade_installer.sh
+++ b/gshade_installer.sh
@@ -648,18 +648,18 @@ XIVinstall() {
   lutrisYaml=($(find "$XDG_CONFIG_HOME"/lutris/games/ -name 'final-fantasy-xiv*' -print 2>/dev/null))
   xlcoreini=($(find "$HOME"/.xlcore/ -name 'launcher.ini' -print 2>/dev/null))
 	
-	if [[ "$IS_MAC" = "true" ]] && [[ -d "/Applications/XIV on Mac.app" ]]; then
-		WINEPREFIX="$HOME/Library/Application Support/XIV on Mac/wineprefix"
-		gameLoc="$(defaults read dezent.XIV-on-Mac GamePath)/game/"
-		gapi=d3d11;
-		printf "\n $gameLoc"
-		printf "\nIf you have a MacBook Pro it's Fn+Shift+f2 to open the gshade window!"
-		printf "\nXIV on Mac detected.\n"
-		printf "\nInstalling...  ";
-		installGame
-		printf "Complete!\n"
-		exit 0
-	fi
+  if [[ "$IS_MAC" = "true" ]] && [[ -d "/Applications/XIV on Mac.app" ]]; then
+    WINEPREFIX="$HOME/Library/Application Support/XIV on Mac/wineprefix"
+    gameLoc="$(defaults read dezent.XIV-on-Mac GamePath)/game/"
+    gapi=d3d11;
+    printf "\n $gameLoc"
+    printf "\nIf you have a MacBook Pro it's Fn+Shift+f2 to open the gshade window!"
+    printf "\nXIV on Mac detected.\n"
+    printf "\nInstalling...  ";
+    installGame
+    printf "Complete!\n"
+    exit 0
+  fi
 
   if [ -z "$WINEPREFIX" ]; then WINEPREFIX="$HOME/.wine"; fi
   if ( validPrefix ); then


### PR DESCRIPTION
Hi, another small one from me.

I've shifted the block for XIV on Mac outside of the check to see if a valid Wine prefix is present. XoM's prefix will always be in the same folder and this allows for users who have XoM installed to use the auto-install option for FFXIV without needing to specify a `WINEPREFIX` variable.